### PR TITLE
Add support for redirect_uri option

### DIFF
--- a/lib/omniauth-channel_advisor/version.rb
+++ b/lib/omniauth-channel_advisor/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module ChannelAdvisor
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/omniauth/strategies/channel_advisor.rb
+++ b/lib/omniauth/strategies/channel_advisor.rb
@@ -14,6 +14,7 @@ module OmniAuth
       # access_type: 'offline'    - retrieve a refresh token http://developers.channeladvisor.com/rest/#917
       # approval_prompt: 'force'  - always show grant screen http://developers.channeladvisor.com/rest/#917
       option :authorize_options, [:scope, :access_type, :approval_prompt]
+      option :redirect_uri
 
       NAME_KEY = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name".freeze
       UID_KEY = "urn:ca:claim:profile".freeze
@@ -30,6 +31,11 @@ module OmniAuth
         {
           'raw_info' => raw_info
         }
+      end
+
+      def callback_url
+        override = options.redirect_uri
+        override ? override : super
       end
 
       def info_hash


### PR DESCRIPTION
ChannelAdvisor only allows a single Redirect URI, and it must exactly match the
value provided when the application was registered in the CA Developer Console.

The default behavior for the OAuth2 strategy is to build the URI based on the
current host. This option allows you to override the value passed back to CA,
regardless of the current host, so that you can make sure to match the registered
value.